### PR TITLE
Added Shaming Endpoint

### DIFF
--- a/Backend/BlameSightBackend/BlameSightBackend/Controllers/BlameController.cs
+++ b/Backend/BlameSightBackend/BlameSightBackend/Controllers/BlameController.cs
@@ -138,6 +138,15 @@ namespace BlameSightBackend.Controllers
             }
 
         }
+        [AllowAnonymous]
+        [HttpGet]
+        [Route("blameShame")]
+        public async Task<IActionResult> getBlameShame(int id)
+        {
+            var shame = await _blameService.getBlameShame();
+            return Ok(shame);
+
+        }
 
         private string getBlamed(string response, int lineNum)
         {

--- a/Backend/BlameSightBackend/BlameSightBackend/Controllers/BlameController.cs
+++ b/Backend/BlameSightBackend/BlameSightBackend/Controllers/BlameController.cs
@@ -88,7 +88,11 @@ namespace BlameSightBackend.Controllers
                 });
 
             };
-            return Ok($"{authorName} was successfully blamed");
+            if(blamedID.Result==blamerID.Result)
+            {
+                return Ok("🤡Woops, looks it is you to blame for this code!\nYou were still successfully blamed.");
+            }
+            return Ok($"{authorName} was successfully blamed.");
         }
         [HttpGet]
         [Route("myBlames")]

--- a/Backend/BlameSightBackend/BlameSightBackend/Models/rankUser.cs
+++ b/Backend/BlameSightBackend/BlameSightBackend/Models/rankUser.cs
@@ -1,0 +1,9 @@
+﻿namespace BlameSightBackend.Models
+{
+    public class rankUser
+    {
+      
+        public string Name { get; set; }
+        public int BlamePoints {  get; set; }
+    }
+}

--- a/Backend/BlameSightBackend/BlameSightBackend/Services/BlameService.cs
+++ b/Backend/BlameSightBackend/BlameSightBackend/Services/BlameService.cs
@@ -91,6 +91,23 @@ namespace BlameSightBackend.Services
             await _dbContext.SaveChangesAsync();
             return true;
         }
+        public async Task<List<rankUser>> getBlameShame()
+        {
 
+            var topUsers = await _dbContext.Blames
+            .Where(e => !e.BlameComplete)
+            .GroupBy(e => e.Blamed)
+            .Select(group => new rankUser
+            {
+            Name = group.Key.UserName,
+            BlamePoints = group.Sum(e => e.UrgencyDescriptorId)?? 0
+            })
+            .OrderByDescending(result => result.BlamePoints)
+            .Take(5)
+            .ToListAsync();
+
+
+            return topUsers;
+        }
     }
 }


### PR DESCRIPTION
# Description

New endpoint at api/Blames/blameShame

- Does not require any auth
- returns a list of the top 5 most blamed people
- points are calculated as the sum urgency id of any open blames
- Intended to shame people for not fixing their code

Also added unique response when you blame yourself.
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update